### PR TITLE
Publish Docker image on every PR

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -2,7 +2,6 @@ name: Build and Push Docker Images
 
 on:
   push: 
-  create:
     tags:
       - v*
 

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -2,7 +2,6 @@ name: Build and Push Docker Images
 
 on:
   push: 
-      - v*
 
 jobs:
   push-github:

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -1,0 +1,32 @@
+name: Build and Push Docker Images
+
+on:
+  pull_request:
+  create:
+    tags:
+      - v*
+
+jobs:
+  push-github:
+    name: Push to GHCR
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - name: Push Docker Image to Github Registry
+        uses: whoan/docker-build-with-cache-action@v5
+        with:
+          # https://docs.github.com/en/packages/learn-github-packages/publishing-a-package
+          username: "${{ secrets.FLYTE_BOT_USERNAME }}"
+          password: "${{ secrets.FLYTE_BOT_PAT }}"
+          image_name: ${{ github.repository_owner }}/flytekit-python-template
+          image_tag: latest,${{ github.sha }},${{ github.event.ref }}
+          push_git_tag: true
+          registry: ghcr.io
+          build_extra_args: "--compress=true"
+          context: ./
+          dockerfile: Dockerfile

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -24,7 +24,7 @@ jobs:
           username: "${{ secrets.FLYTE_BOT_USERNAME }}"
           password: "${{ secrets.FLYTE_BOT_PAT }}"
           image_name: ${{ github.repository_owner }}/flytekit-python-template
-          image_tag: latest,${{ github.sha }},${{ github.event.ref }}
+          image_tag: latest,${{ github.sha }}
           push_git_tag: true
           registry: ghcr.io
           build_extra_args: "--compress=true"

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -2,7 +2,6 @@ name: Build and Push Docker Images
 
 on:
   push: 
-    tags:
       - v*
 
 jobs:

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -1,7 +1,7 @@
 name: Build and Push Docker Images
 
 on:
-  pull_request:
+  push: 
   create:
     tags:
       - v*


### PR DESCRIPTION
It'll be useful to expose this repo as a publicly accessible docker image so we can use it in the getting started guide along with fast-register. This lets us avoid requiring users to build (and in the case of remote Flyte deployments) push their docker images somewhere accessible