### PR TITLE
Fix passing INSECURE and NOPUSH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ VERSION=$(shell ./version.sh)
 
 # If you're port-forwarding your service or running the sandbox Flyte deployment you can leave this is as is.
 # If you want to use a secure channel with ssl enabled, be sure **not** to use the insecure flag.
-ifeq ($(INSECURE), "true")
+ifeq ($(INSECURE), true)
 	INSECURE=-i
 endif
 
-ifeq ($(NOPUSH), "true")
+ifeq ($(NOPUSH), true)
 	NOPUSH=1
 endif
 


### PR DESCRIPTION
`ifeq` uses literal `"` in equality check, so passing in `INSECURE=true` to `make fast_register` was failing.
```
FLYTE_AWS_ENDPOINT=http://localhost:30084/ FLYTE_AWS_ACCESS_KEY_ID=minio FLYTE_AWS_SECRET_ACCESS_KEY=miniostorage INSECURE=true make fast_register
```
```
...
flyte-cli fast-register-files -h localhost:30081 true -p flyteexamples -d development \
		--additional-distribution-dir s3://my-s3-bucket/flyte-fast-distributions _pb_output/*
Config file not found at default location, relying on environment variables instead.
                        To setup your config file run 'flyte-cli setup-config'
Usage: flyte-cli fast-register-files [OPTIONS] [FILES]...
Try 'flyte-cli fast-register-files --help' for help.
Error: Invalid value for '[FILES]...': Path 'true' does not exist.
make: *** [fast_register] Error 2
```
Discovered while running through the [Getting Started](https://docs.flyte.org/en/latest/getting_started.html), which I think also needs to be updated to pass in `INSECURE=true`.

### Testing
Ran the above command successfully.

