### PR TITLE
Ensure curl is installed in the instructions to run on GCP

### DIFF
--- a/simple-example/{{cookiecutter.project_name}}/Dockerfile
+++ b/simple-example/{{cookiecutter.project_name}}/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get update && apt-get install -y build-essential
 
 # Install the AWS cli separately to prevent issues with boto being written over
 RUN pip3 install awscli
+
 # Similarly, if you're using GCP be sure to update this command to install gsutil
+# RUN apt-get install -y curl
 # RUN curl -sSL https://sdk.cloud.google.com | bash
 # ENV PATH="$PATH:/root/google-cloud-sdk/bin"
 


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

The `python:3.8-slim-buster` image does not contain `curl`, but that's necessary to follow GCP instructions.