### PR TITLE
added -y option to docker_build.sh. I also fixed a  bug on -p option

### DIFF
--- a/simple-example/{{cookiecutter.project_name}}/Dockerfile
+++ b/simple-example/{{cookiecutter.project_name}}/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.8-slim-buster
+ARG PYTHON_VERSION
+FROM python:${PYTHON_VERSION}-slim-buster
 
 WORKDIR /root
 ENV VENV /opt/venv

--- a/simple-example/{{cookiecutter.project_name}}/docker_build.sh
+++ b/simple-example/{{cookiecutter.project_name}}/docker_build.sh
@@ -6,24 +6,34 @@ set -e
 REGISTRY=""
 
 # SET the appname here
-PROJECT_NAME="{{ cookiecutter.project_name }}"
+PROJECT_NAME="spx_prediction"
 
-while getopts a:r:v:h flag
+while getopts p:r:v:y:e:h flag
 do
     case "${flag}" in
         p) PROJECT_NAME=${OPTARG};;
         r) REGISTRY=${OPTARG};;
         v) VERSION=${OPTARG};;
+        y) PYTHON_VERSION=${OPTARG};;
         h) echo "Usage: ${0} [-h|[-p <project_name>][-r <registry_name>][-v <version>]]"
-           echo "  h: help (this message)"
-           echo "  p: PROJECT_NAME for your workflows. Defaults to '{{ cookiecutter.project_name }}'."
+           echo "  p: PROJECT_NAME for your workflows. Defaults to 'spx_prediction'."
            echo "  r: REGISTRY name where the docker container should be pushed. Defaults to none - localhost"
            echo "  v: VERSION of the build. Defaults to using the current git head SHA"
+           echo "  y: PYTHON_VERSION of the build. Default is 3.8"           
+           echo "  h: help (this message)"
            exit 1;;
-        *) echo "Usage: ${0} [-h|[-a <project_name>][-r <registry_name>][-v <version>]]"
+        *) echo "Usage: ${0} [-h|[-p <project_name>][-r <registry_name>][-v <version>]]"
            exit 1;;
     esac
 done
+
+echo ${PYTHON_VERSION}
+
+if [ -z "${PYTHON_VERSION}" ]; then
+  echo "No python version set, using 3.8 as default"
+  PYTHON_VERSION="3.8"
+fi
+
 
 # If you are using git, then this will automatically use the git head as the
 # version
@@ -40,7 +50,23 @@ else
  echo "Registry set: creating tag ${TAG}"
 fi
 
-# Should be run in the folder that has Dockerfile
-docker build --tag ${TAG} .
+# convert *.ipynb to *.py
+if hash jupyter 2>/dev/null; then
+    echo "Jupyter found. converting workflows/*.ipython to *.py"
+    jupyter nbconvert workflows/*.ipynb --to script
+else
+    echo "Jupyter not found"
+fi
+
+# generate requirements.txt if pipenv were used
+if hash pipenv 2>/dev/null;then
+    echo "Pipenv found. Generating requirements.txt"
+    pipenv run pip freeze > requirements.txt
+else
+    echo "Pipenv not found"
+fi
+
+docker build --tag ${TAG} --build-arg PYTHON_VERSION=${PYTHON_VERSION} .
 
 echo "Docker image built with tag ${TAG}. You can use this image to run pyflyte package."
+


### PR DESCRIPTION
I had added a couple of features to the sample template. I also fixed a bug in docker_build.sh

- Now -p option works correctly.
- By providing -y option, you can specify a version of Python. Default is 3.8
- If pipenv is in the path, requirements.txt will be generated through `pip freeze`
- If jupyter is in the path, workflows/*.ipynb will be transformed to *.py files. 