### PR TITLE
GHCR Image Registry Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@ In this repository you'll find a collection of [cookiecutter](https://cookiecutt
 
 We use cookiecutter's ability to define [multiple templates to be defined in the same repository](https://cookiecutter.readthedocs.io/en/latest/advanced/directories.html). Each cookiecutter template is defined in a separate directory, e.g. the template used in Flyte's [Getting Started](https://docs.flyte.org/en/latest/getting_started.html) guide lives in a directory called `simple-example`.
 
+## Images
+Compiled Images for all templates can be found in our [ghcr.io registry](https://github.com/flyteorg/flytekit-python-template/pkgs/container/flytekit-python-template)
+
 ## Usage
 
 Each template can be rendered by specifying the `--directory` flag to cookiecutter. For example, in order to generate a project using the `simple-example` template run:


### PR DESCRIPTION
Adds a link to the ghcr.io image registry page for flytekit-python-template
https://github.com/flyteorg/flytekit-python-template/pkgs/container/flytekit-python-template