### PR TITLE
Add support for pkce auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.venv


### PR DESCRIPTION
This change adds auth type and support for Pkce auth. Client id and secret are only required when auth type is `CLIENT_CREDENTIALS`, which remains as the default