### PR TITLE
[HOTFIX] __init__ usage broke standard template usage

### DIFF
--- a/bayesian-optimization/{{cookiecutter.project_name}}/workflows/__init__.py
+++ b/bayesian-optimization/{{cookiecutter.project_name}}/workflows/__init__.py
@@ -1,1 +1,1 @@
-from .bayesian_optimization_example import wf as wf
+from .bayesian_optimization_example import *

--- a/bayesian-optimization/{{cookiecutter.project_name}}/workflows/__init__.py
+++ b/bayesian-optimization/{{cookiecutter.project_name}}/workflows/__init__.py
@@ -1,1 +1,0 @@
-from .bayesian_optimization_example import *

--- a/integration.py
+++ b/integration.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
     platform_args = {'endpoint': args.host, 'auth_mode': auth_type, 'insecure': args.insecure}
     if auth_type == AuthType.CLIENT_CREDENTIALS:
         platform_args['client_id'] = args.client_id
-        platform_args['client_secret'] = args.client_secret
+        platform_args['client_credentials_secret'] = args.client_secret
     remote = FlyteRemote(
         config=Config(
             platform=PlatformConfig(**platform_args),

--- a/mnist-training/{{cookiecutter.project_name}}/workflows/__init__.py
+++ b/mnist-training/{{cookiecutter.project_name}}/workflows/__init__.py
@@ -1,1 +1,0 @@
-from .mnist_training_example import *

--- a/mnist-training/{{cookiecutter.project_name}}/workflows/__init__.py
+++ b/mnist-training/{{cookiecutter.project_name}}/workflows/__init__.py
@@ -1,2 +1,1 @@
-from .mnist_training_example import mnist_workflow_cpu as mnist_workflow_cpu
-from .mnist_training_example import mnist_workflow_gpu as mnist_workflow_gpu
+from .mnist_training_example import *

--- a/mnist-training/{{cookiecutter.project_name}}/workflows/mnist_training_example.py
+++ b/mnist-training/{{cookiecutter.project_name}}/workflows/mnist_training_example.py
@@ -11,7 +11,7 @@ The model is trained for 10 epochs and the validation loss is calculated on the 
 """
 
 
-@task
+@task(requests=Resources(cpu="1", mem="1Gi", ephemeral_storage="10Gi"))
 def get_dataset(training: bool, gpu: bool = False) -> DataLoader:
     """
     This task downloads the MNIST dataset and returns a dataloader for the dataset.
@@ -26,7 +26,7 @@ def get_dataset(training: bool, gpu: bool = False) -> DataLoader:
     return dataloader
 
 
-@task(requests=Resources(cpu="2", mem="10Gi"))
+@task(requests=Resources(cpu="2", mem="10Gi", ephemeral_storage="10Gi"))
 def train_cpu(dataset: DataLoader, n_epochs: int) -> th.nn.Sequential:
     """
     This task trains the model for the specified number of epochs.
@@ -36,7 +36,7 @@ def train_cpu(dataset: DataLoader, n_epochs: int) -> th.nn.Sequential:
     return train_model(model=model, optim=optim, dataset=dataset, n_epochs=n_epochs)
 
 
-@task(requests=Resources(gpu="1", mem="10Gi"))
+@task(requests=Resources(gpu="1", mem="10Gi", ephemeral_storage="10Gi"))
 def train_gpu(dataset: DataLoader, n_epochs: int) -> th.nn.Sequential:
     """
     This task trains the model for the specified number of epochs.
@@ -46,7 +46,7 @@ def train_gpu(dataset: DataLoader, n_epochs: int) -> th.nn.Sequential:
     return train_model(model=model, optim=optim, dataset=dataset, n_epochs=n_epochs)
 
 
-@task(requests=Resources(cpu="2", mem="10Gi"))
+@task(requests=Resources(cpu="2", mem="10Gi", ephemeral_storage="15Gi"))
 def validation_loss(model: th.nn.Sequential, dataset: DataLoader) -> str:
     """
     This task calculates the validation loss on the test set.

--- a/simple-example/{{cookiecutter.project_name}}/workflows/__init__.py
+++ b/simple-example/{{cookiecutter.project_name}}/workflows/__init__.py
@@ -1,1 +1,0 @@
-from .example import *

--- a/simple-example/{{cookiecutter.project_name}}/workflows/__init__.py
+++ b/simple-example/{{cookiecutter.project_name}}/workflows/__init__.py
@@ -1,1 +1,1 @@
-from .example import wf as wf
+from .example import *

--- a/wine-classification/{{cookiecutter.project_name}}/workflows/__init__.py
+++ b/wine-classification/{{cookiecutter.project_name}}/workflows/__init__.py
@@ -1,1 +1,0 @@
-from .wine_classification_example import *

--- a/wine-classification/{{cookiecutter.project_name}}/workflows/__init__.py
+++ b/wine-classification/{{cookiecutter.project_name}}/workflows/__init__.py
@@ -1,1 +1,1 @@
-from .wine_classification_example import training_workflow as training_workflow
+from .wine_classification_example import *


### PR DESCRIPTION
This change fixes an issue that was caused with the introduction of integration.py, adding a __init__ that had a fixed workflow name caused workflow registration to fail whenever a user renamed their workflow, but didn't adjust the __init__ import.

This is unexpected and unintentional behavior, which is corrected and tested with this fix by wildcard importing the workflow components into integration.py instead.