### PR TITLE
fix build_docker.sh files for flag issue: -a vs -p

### DIFF
--- a/bayesian-optimization/{{cookiecutter.project_name}}/docker_build.sh
+++ b/bayesian-optimization/{{cookiecutter.project_name}}/docker_build.sh
@@ -8,10 +8,10 @@ REGISTRY=""
 # SET the appname here
 PROJECT_NAME="{{ cookiecutter.project_name }}"
 
-while getopts a:r:v:h flag
+while getopts a:p:r:v:h flag
 do
     case "${flag}" in
-        p) PROJECT_NAME=${OPTARG};;
+        a|p) PROJECT_NAME=${OPTARG};;
         r) REGISTRY=${OPTARG};;
         v) VERSION=${OPTARG};;
         h) echo "Usage: ${0} [-h|[-p <project_name>][-r <registry_name>][-v <version>]]"
@@ -20,7 +20,7 @@ do
            echo "  r: REGISTRY name where the docker container should be pushed. Defaults to none - localhost"
            echo "  v: VERSION of the build. Defaults to using the current git head SHA"
            exit 1;;
-        *) echo "Usage: ${0} [-h|[-a <project_name>][-r <registry_name>][-v <version>]]"
+        *) echo "Usage: ${0} [-h|[-p <project_name>][-r <registry_name>][-v <version>]]"
            exit 1;;
     esac
 done

--- a/mnist-training/{{cookiecutter.project_name}}/docker_build.sh
+++ b/mnist-training/{{cookiecutter.project_name}}/docker_build.sh
@@ -8,10 +8,10 @@ REGISTRY=""
 # SET the appname here
 PROJECT_NAME="{{ cookiecutter.project_name }}"
 
-while getopts a:r:v:h flag
+while getopts a:p:r:v:h flag
 do
     case "${flag}" in
-        p) PROJECT_NAME=${OPTARG};;
+        a|p) PROJECT_NAME=${OPTARG};;
         r) REGISTRY=${OPTARG};;
         v) VERSION=${OPTARG};;
         h) echo "Usage: ${0} [-h|[-p <project_name>][-r <registry_name>][-v <version>]]"
@@ -20,7 +20,7 @@ do
            echo "  r: REGISTRY name where the docker container should be pushed. Defaults to none - localhost"
            echo "  v: VERSION of the build. Defaults to using the current git head SHA"
            exit 1;;
-        *) echo "Usage: ${0} [-h|[-a <project_name>][-r <registry_name>][-v <version>]]"
+        *) echo "Usage: ${0} [-h|[-p <project_name>][-r <registry_name>][-v <version>]]"
            exit 1;;
     esac
 done

--- a/simple-example/{{cookiecutter.project_name}}/docker_build.sh
+++ b/simple-example/{{cookiecutter.project_name}}/docker_build.sh
@@ -8,10 +8,10 @@ REGISTRY=""
 # SET the appname here
 PROJECT_NAME="{{ cookiecutter.project_name }}"
 
-while getopts a:r:v:h flag
+while getopts a:p:r:v:h flag
 do
     case "${flag}" in
-        p) PROJECT_NAME=${OPTARG};;
+        a|p) PROJECT_NAME=${OPTARG};;
         r) REGISTRY=${OPTARG};;
         v) VERSION=${OPTARG};;
         h) echo "Usage: ${0} [-h|[-p <project_name>][-r <registry_name>][-v <version>]]"
@@ -20,7 +20,7 @@ do
            echo "  r: REGISTRY name where the docker container should be pushed. Defaults to none - localhost"
            echo "  v: VERSION of the build. Defaults to using the current git head SHA"
            exit 1;;
-        *) echo "Usage: ${0} [-h|[-a <project_name>][-r <registry_name>][-v <version>]]"
+        *) echo "Usage: ${0} [-h|[-p <project_name>][-r <registry_name>][-v <version>]]"
            exit 1;;
     esac
 done


### PR DESCRIPTION
## Issue

The 3 existing (identical) `docker_build.sh` files all had help text describing both an `-a` and a `-p` flag for setting the project name, but only a `-a` was allowed.

## Fix
This will allow _either_ `-a` or `-p` to set the project name, to be compatible with existing uses and the help text.
Note that I did omit the `-a` from the help text: it now only prints the `-p` option.