### PR TITLE
[Docs] Modify the docstring of the workflow wf

### DIFF
--- a/basic-template-imagespec/{{cookiecutter.project_name}}/workflows/example.py
+++ b/basic-template-imagespec/{{cookiecutter.project_name}}/workflows/example.py
@@ -50,7 +50,7 @@ def wf(name: str = "world") -> typing.Tuple[str, int]:
 
     The @workflow decorator defines an execution graph that is composed of
     tasks and potentially sub-workflows. In this simple example, the workflow
-    is composed of just one task.
+    is composed of two tasks, including `say_hello` and `greeting_length`.
 
     There are a few important things to note about workflows:
     - Workflows are a domain-specific language (DSL) for creating execution


### PR DESCRIPTION
The workflow `wf` actually contains two tasks (including `say_hello` and `greeting_length`), instead of one. Following shows the corresponding DAG in FlyteConsole:

![Screenshot 2024-10-26 at 12 12 00 AM](https://github.com/user-attachments/assets/9acdbc3f-613f-4058-a0fc-ab3bbcfdbc81)

